### PR TITLE
Hack to Adjust Sizes on Mobile

### DIFF
--- a/src/screens/MainScreen/components/SizePicker/index.js
+++ b/src/screens/MainScreen/components/SizePicker/index.js
@@ -3,6 +3,22 @@ import { isMobileOnly } from "react-device-detect";
 import { Container, Label, SizeButton, SizeButtonGroup } from "./styles";
 import theme from "../../../../theme";
 
+const convertSizeToString = size => {
+  if (isMobileOnly) {
+    switch (size) {
+      case "XS":
+        return "S";
+      case "S":
+        return "M";
+      case "M":
+        return "L";
+      default:
+        return size;
+    }
+  }
+  return size;
+};
+
 const SizePicker = ({ selectedSize, setCartSize }) => {
   const sizes = isMobileOnly
     ? theme.carts.sizes.mobile
@@ -19,7 +35,7 @@ const SizePicker = ({ selectedSize, setCartSize }) => {
             }}
             selected={selectedSize === size}
           >
-            {size}
+            {convertSizeToString(size)}
           </SizeButton>
         ))}
       </SizeButtonGroup>


### PR DESCRIPTION
Since the "XS", "S", "M", "L", "XL" options are hard-coded into the logic of the app, this hack lets us display "S", "M", "L" for mobile users while still using "XS", "S", "M" under the hood