### PR TITLE
no need to unmount form

### DIFF
--- a/src/screens/MainScreen/index.js
+++ b/src/screens/MainScreen/index.js
@@ -174,14 +174,11 @@ const MainScreen = () => {
         <Modal.Header closeButton>
           <ModalTitle>Board the Hummus Train!</ModalTitle>
         </Modal.Header>
-        {// manually unmount the form to reset state on close
-        modalVisible && (
-          <AddCartForm
-            onSubmit={onAddCartFormSubmit}
-            progress={formUploadProgress}
-            uploading={uploading}
-          />
-        )}
+        <AddCartForm
+          onSubmit={onAddCartFormSubmit}
+          progress={formUploadProgress}
+          uploading={uploading}
+        />
       </Modal>
     </Container>
   );


### PR DESCRIPTION
With the move to use React Bootstrap Modals over Rodal, the Modal automatically unmounts its contents and resets the state, so there's no need for us to do it ourselves (would make modal look weird as it's disappearing)